### PR TITLE
Fix logger stream return bug and improve tests

### DIFF
--- a/TODO
+++ b/TODO
@@ -2,4 +2,4 @@ busynet
 http
 ini file
 benchmark
-until test
+unit test

--- a/busylib/base/logger.cc
+++ b/busylib/base/logger.cc
@@ -61,6 +61,7 @@ LogStream &Logger::stream(const char *fmt, ...)
     stream_ << buffer;
   }
   va_end(ap);
+  return stream_;
 }
 
 template <int N>
@@ -79,6 +80,7 @@ LogStream &LogStream::operator<<(const i32 n)
     char num_buf[12];
     sprintf(num_buf, "%d", n);
     buffer_.append(num_buf, strlen(num_buf));
+    return *this;
 }
 
 LogStream &LogStream::operator<<(const char *str)
@@ -92,6 +94,6 @@ LogStream &LogStream::operator<<(const char *str)
 
 LogStream &LogStream::operator<<(const std::string &str)
 {
-  operator<<(str.c_str());
+  return (*this) << str.c_str();
 }
 }

--- a/test/logger_ut.cc
+++ b/test/logger_ut.cc
@@ -3,8 +3,13 @@
 
 using namespace busylib;
 
-TEST_CASE("vectors can be sized and resized", "[vector]")
+TEST_CASE("logger prints formatted messages", "[logger]")
 {
+  Logger::setLevel(Logger::LOG_INFO);
   logInfo("Test format string: 5 = %d", 5);
   logInfo("Test append string: 5 = ") << 5;
+
+  Logger::setLevel(Logger::LOG_DEBUG);
+  REQUIRE(Logger::level() == Logger::LOG_DEBUG);
+  Logger::setLevel(Logger::LOG_INFO);
 }


### PR DESCRIPTION
## Summary
- fix missing return values in logger stream operators
- correct TODO list typo
- update logger unit test description and add log level check

## Testing
- `cmake ..`
- `cmake --build .`
- `g++ -std=gnu++11 -DCATCH_CONFIG_NO_POSIX_SIGNALS ../test/logger_ut.cc -I.. -I../busylib -L./busylib/base -lbusylib_base -L./busylib/util -lbusylib_util -pthread -o logger_ut && ./logger_ut`
- `./test/test` *(fails: program hung, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c8082cc6288329add4167ae08bb213